### PR TITLE
configure files for TH-2 papp added

### DIFF
--- a/computers/paratera-th2/README
+++ b/computers/paratera-th2/README
@@ -1,0 +1,4 @@
+#### NOTE
+
+The hostname of the computer maybe different depend on the proxy host provide by paratera.
+If the username is `<user>@<location>` then the user directory should be setting to `/PARA/<user>/aiida`. 

--- a/computers/paratera-th2/paratera-th2.yml
+++ b/computers/paratera-th2/paratera-th2.yml
@@ -1,0 +1,13 @@
+---
+label: paratera-th2
+description: TianHe-2 supercomputer provided by paratera
+hostname: 119.90.38.52
+transport: ssh
+scheduler: slurm
+shebang: '#!/usr/bin/env bash'
+work_dir: /PARA/{username}/aiida
+mpirun_command: 'srun -n {tot_num_mpiprocs}'
+mpiprocs_per_machine: 24
+prepend_text: ''
+append_text: ''
+

--- a/computers/paratera-th2/pw65@paratera-th2.yml
+++ b/computers/paratera-th2/pw65@paratera-th2.yml
@@ -1,0 +1,12 @@
+---
+label: "pw6.5"
+description: "quantum_espresso v6.5"
+input_plugin: "quantumespresso.pw"
+on_computer: true
+remote_abs_path: "/WORK/app/Quantum_Espresso/6.5-MPI/bin/pw.x"
+computer: "papp"
+prepend_text: |
+  ulimit -s unlimited
+  source /PARA/app/scripts/cn-module.sh
+  module load Quantum_Espresso/6.5-icc-15.0.1
+append_text: " "


### PR DESCRIPTION
@ltalirz This is the configure files (template) for connecting to remote computer provided by paratera, over direct SSHv2. I keep the directory structure as `<dir user>/<dir computer>/<conf files>` .