### PR TITLE
Set mpiprocs_per_machine to 128.

### DIFF
--- a/eiger.cscs.ch/multicore-mr0-debug/computer-setup.yaml
+++ b/eiger.cscs.ch/multicore-mr0-debug/computer-setup.yaml
@@ -6,7 +6,7 @@ scheduler: slurm
 work_dir: "/scratch/e1000/{username}/aiida/"
 shebang: "#!/bin/bash"
 mpirun_command: "srun -n {tot_num_mpiprocs}"
-mpiprocs_per_machine: 64
+mpiprocs_per_machine: 128
 prepend_text: |
     ### computer prepend_text start ###
     #SBATCH --partition=debug

--- a/eiger.cscs.ch/multicore-mr0/computer-setup.yaml
+++ b/eiger.cscs.ch/multicore-mr0/computer-setup.yaml
@@ -6,7 +6,7 @@ scheduler: slurm
 work_dir: "/scratch/e1000/{username}/aiida/"
 shebang: "#!/bin/bash"
 mpirun_command: "srun -n {tot_num_mpiprocs}"
-mpiprocs_per_machine: 64
+mpiprocs_per_machine: 128
 prepend_text: |
     ### computer prepend_text start ###
     #SBATCH --partition=normal


### PR DESCRIPTION
Each node has two sockets with 64 cores each.