### PR TITLE
✨ NEW: Add AiiDA v2.X support for `eiger`

### DIFF
--- a/eiger.cscs.ch/codes-installed/qe-7.0-hp@eiger.yaml
+++ b/eiger.cscs.ch/codes-installed/qe-7.0-hp@eiger.yaml
@@ -1,0 +1,11 @@
+label: qe-7.0-hp
+description: Quantum ESPRESSO hp.x v7.0 Compiled with CpeIntel v21.12
+default_calc_job_plugin: quantumespresso.hp
+computer: eiger
+filepath_executable: /apps/pilatus/UES/jenkins/1.4.0/software/QuantumESPRESSO/7.0-cpeIntel-21.12/bin/hp.x
+prepend_text: |+
+  module load cpeIntel
+  module load QuantumESPRESSO/7.0
+
+  export OMP_NUM_THREADS=1
+append_text: ' '

--- a/eiger.cscs.ch/codes-installed/qe-7.0-ph@eiger.yaml
+++ b/eiger.cscs.ch/codes-installed/qe-7.0-ph@eiger.yaml
@@ -1,0 +1,11 @@
+label: qe-7.0-ph
+description: Quantum ESPRESSO ph.x v7.0 Compiled with CpeIntel v21.12
+default_calc_job_plugin: quantumespresso.ph
+computer: eiger
+filepath_executable: /apps/pilatus/UES/jenkins/1.4.0/software/QuantumESPRESSO/7.0-cpeIntel-21.12/bin/ph.x
+prepend_text: |+
+  module load cpeIntel
+  module load QuantumESPRESSO/7.0
+
+  export OMP_NUM_THREADS=1
+append_text: ' '

--- a/eiger.cscs.ch/codes-installed/qe-7.0-projwfc@eiger.yaml
+++ b/eiger.cscs.ch/codes-installed/qe-7.0-projwfc@eiger.yaml
@@ -1,0 +1,11 @@
+label: qe-7.0-projwfc
+description: Quantum ESPRESSO projwfc.x v7.0 Compiled with CpeIntel v21.12
+default_calc_job_plugin: quantumespresso.projwfc
+computer: eiger
+filepath_executable: /apps/pilatus/UES/jenkins/1.4.0/software/QuantumESPRESSO/7.0-cpeIntel-21.12/bin/projwfc.x
+prepend_text: |+
+  module load cpeIntel
+  module load QuantumESPRESSO/7.0
+
+  export OMP_NUM_THREADS=1
+append_text: ' '

--- a/eiger.cscs.ch/codes-installed/qe-7.0-pw@eiger.yaml
+++ b/eiger.cscs.ch/codes-installed/qe-7.0-pw@eiger.yaml
@@ -1,0 +1,11 @@
+label: qe-7.0-pw
+description: Quantum ESPRESSO pw.x v7.0 Compiled with CpeIntel v21.12
+default_calc_job_plugin: quantumespresso.pw
+computer: eiger
+filepath_executable: /apps/pilatus/UES/jenkins/1.4.0/software/QuantumESPRESSO/7.0-cpeIntel-21.12/bin/pw.x
+prepend_text: |+
+  module load cpeIntel
+  module load QuantumESPRESSO/7.0
+
+  export OMP_NUM_THREADS=1
+append_text: ' '

--- a/eiger.cscs.ch/codes-installed/qe-7.0-q2r@eiger.yaml
+++ b/eiger.cscs.ch/codes-installed/qe-7.0-q2r@eiger.yaml
@@ -1,0 +1,11 @@
+label: qe-7.0-q2r
+description: Quantum ESPRESSO q2r.x v7.0 Compiled with CpeIntel v21.12
+default_calc_job_plugin: quantumespresso.q2r
+computer: eiger
+filepath_executable: /apps/pilatus/UES/jenkins/1.4.0/software/QuantumESPRESSO/7.0-cpeIntel-21.12/bin/q2r.x
+prepend_text: |+
+  module load cpeIntel
+  module load QuantumESPRESSO/7.0
+
+  export OMP_NUM_THREADS=1
+append_text: ' '

--- a/eiger.cscs.ch/multicore-mr0/computer-configure.yaml
+++ b/eiger.cscs.ch/multicore-mr0/computer-configure.yaml
@@ -1,3 +1,2 @@
----
 safe_interval: 60
 proxy_command: ssh -q -Y {username}@ela.cscs.ch netcat eiger.cscs.ch 22

--- a/eiger.cscs.ch/multicore-mr0/computer-setup.yaml
+++ b/eiger.cscs.ch/multicore-mr0/computer-setup.yaml
@@ -1,17 +1,16 @@
----
-label: eiger-mc-mr0
+label: eiger
 hostname: eiger.cscs.ch
 description: Eiger is the production partition on Alps, the HPE Cray EX Supercomputer.
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /scratch/e1000/{username}/aiida/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}
 mpiprocs_per_machine: 128
+default_memory_per_machine: 255000000
+use_double_quotes: 'N'
 prepend_text: |
     ### computer prepend_text start ###
-    #SBATCH --partition=normal
-    #SBATCH --account=mr0
     #SBATCH --constraint=mc
     #SBATCH --hint=nomultithread
 


### PR DESCRIPTION
Just updated the Eiger computer and code setup files for a bunch of QE codes. Tested in the field, except for the configuration. Still a draft PR for this reason, as well as the fact that we should probably have a separate configuration directory for v2.X computers. For codes I think it's a good idea to have different folders for the different types, which I already integrated here.

@yakutovicha what do you think? From an AiiDAlab infrastructure point of view, how would you provide support for v1 & v2?