### PR TITLE
update mpiprocs_per_machine for merlin

### DIFF
--- a/merlin.psi.ch/cpu/computer-setup.yaml
+++ b/merlin.psi.ch/cpu/computer-setup.yaml
@@ -7,7 +7,7 @@ scheduler: slurm
 work_dir: /shared-scratch/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}
-mpiprocs_per_machine: 1
+mpiprocs_per_machine: 44
 prepend_text: |
     ### computer prepend_text start ###
     #SBATCH --cluster=merlin6

--- a/merlin.psi.ch/gpu/computer-setup.yaml
+++ b/merlin.psi.ch/gpu/computer-setup.yaml
@@ -7,7 +7,7 @@ scheduler: slurm
 work_dir: /shared-scratch/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}
-mpiprocs_per_machine: 1
+mpiprocs_per_machine: 20
 prepend_text: |
     ### computer prepend_text start ###
     #SBATCH --cluster=gmerlin6


### PR DESCRIPTION

Fix https://github.com/aiidalab/aiidalab-qe/issues/413

On Merlin 6, for CPU cluster, the max CPUs is 44. For GPU cluster, the max CPUs depends on the nodes, I set 20 here, because ~ 80% of nodes have a max CPUs of 20.
