### PR TITLE
Fixes to make configs compatible with latest aiida-core and CSCS

### DIFF
--- a/daint.cscs.ch/hybrid-s1141/computer-setup.yaml
+++ b/daint.cscs.ch/hybrid-s1141/computer-setup.yaml
@@ -1,13 +1,11 @@
 ---
 label: daint-hybrid-s1141
-hostname: daint.cscs.ch
+hostname: daint.alps.cscs.ch
 description: Piz Daint supercomputer at CSCS Lugano, Switzerland, using the hybrid partition. Project s1141
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 shebang: '#!/bin/bash -l'
 mpiprocs_per_machine: 12
-num_cores_per_mpiproc: 1
-queue_name: normal
 work_dir: /scratch/snx3000/{username}/aiida/
 mpirun_command: srun -n {tot_num_mpiprocs}
 prepend_text: |

--- a/daint.cscs.ch/hybrid/computer-setup.yaml
+++ b/daint.cscs.ch/hybrid/computer-setup.yaml
@@ -1,13 +1,11 @@
 ---
 label: daint-hybrid
-hostname: daint.cscs.ch
+hostname: daint.alps.cscs.ch
 description: Piz Daint supercomputer at CSCS Lugano, Switzerland, using the hybrid partition. HyperThreading is off
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 shebang: '#!/bin/bash -l'
 mpiprocs_per_machine: 12
-num_cores_per_mpiproc: 1
-queue_name: normal
 work_dir: /scratch/snx3000/{username}/aiida/
 mpirun_command: srun -n {tot_num_mpiprocs}
 prepend_text: |

--- a/daint.cscs.ch/multicore-em01/computer-setup.yaml
+++ b/daint.cscs.ch/multicore-em01/computer-setup.yaml
@@ -1,9 +1,9 @@
 ---
 label: daint-mc-em01
-hostname: daint.cscs.ch
+hostname: daint.alps.cscs.ch
 description: Piz Daint supercomputer at CSCS Lugano, Switzerland, multicore partition, em01 account.
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /scratch/snx3000/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/daint.cscs.ch/multicore/computer-setup.yaml
+++ b/daint.cscs.ch/multicore/computer-setup.yaml
@@ -1,9 +1,9 @@
 ---
 label: daint-mc
-hostname: daint.cscs.ch
+hostname: daint.alps.cscs.ch
 description: Piz Daint supercomputer at CSCS Lugano, Switzerland, multicore partition.
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /scratch/snx3000/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/eiger.cscs.ch/multicore-mr0-debug/computer-setup.yaml
+++ b/eiger.cscs.ch/multicore-mr0-debug/computer-setup.yaml
@@ -1,9 +1,9 @@
 ---
 label: eiger-mc-mr0-debug
-hostname: eiger.cscs.ch
+hostname: eiger.alps.cscs.ch
 description: Eiger is the production partition on Alps, the HPE Cray EX Supercomputer.
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /scratch/e1000/{username}/aiida/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/eiger.cscs.ch/multicore-mr0/computer-setup.yaml
+++ b/eiger.cscs.ch/multicore-mr0/computer-setup.yaml
@@ -1,9 +1,9 @@
 ---
 label: eiger-mc-mr0
-hostname: eiger.cscs.ch
+hostname: eiger.alps.cscs.ch
 description: Eiger is the production partition on Alps, the HPE Cray EX Supercomputer.
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /scratch/e1000/{username}/aiida/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/fidis.epfl.ch/fidis-serial/computer-setup.yaml
+++ b/fidis.epfl.ch/fidis-serial/computer-setup.yaml
@@ -2,8 +2,8 @@
 label: fidis-serial
 hostname: fidis.epfl.ch
 description: Fidis EPFL computer using serial partition
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /scratch/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/fidis.epfl.ch/fidis/computer-setup.yaml
+++ b/fidis.epfl.ch/fidis/computer-setup.yaml
@@ -2,8 +2,8 @@
 label: fidis
 hostname: fidis.epfl.ch
 description: fidis EPFL computer
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /scratch/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/imxgesrv1.epfl.ch/imxgesrv1/computer-setup.yaml
+++ b/imxgesrv1.epfl.ch/imxgesrv1/computer-setup.yaml
@@ -2,8 +2,8 @@
 label: imxgesrv1
 hostname: imxgesrv1.epfl.ch
 description: imxgesrv EPFL computer
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /exports/commonscratch/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/lsmosrv6/ch315/computer-setup.yaml
+++ b/lsmosrv6/ch315/computer-setup.yaml
@@ -2,8 +2,8 @@
 label: ch315
 hostname: lsmosrv6.epfl.ch
 description: Local server ch315 at LSMO
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /home/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/merlin.psi.ch/cpu/computer-setup.yaml
+++ b/merlin.psi.ch/cpu/computer-setup.yaml
@@ -2,8 +2,8 @@
 label: merlin6
 hostname: merlin-l-01.psi.ch
 description: Merlin6 HPC at PSI
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /shared-scratch/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/merlin.psi.ch/gpu/computer-setup.yaml
+++ b/merlin.psi.ch/gpu/computer-setup.yaml
@@ -2,8 +2,8 @@
 label: merlin6
 hostname: merlin-l-01.psi.ch
 description: Merlin6 HPC at PSI
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 work_dir: /shared-scratch/{username}/aiida_run/
 shebang: '#!/bin/bash'
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/paratera/tianhe-2/computer-setup.yaml
+++ b/paratera/tianhe-2/computer-setup.yaml
@@ -2,8 +2,8 @@
 label: paratera-th2
 description: TianHe-2 supercomputer provided by paratera
 hostname: 119.90.38.52
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 shebang: '#!/usr/bin/env bash'
 work_dir: /PARA/{username}/aiida
 mpirun_command: srun -n {tot_num_mpiprocs}

--- a/tigu.empa.ch/tigu-mpirun/computer-setup.yaml
+++ b/tigu.empa.ch/tigu-mpirun/computer-setup.yaml
@@ -2,11 +2,10 @@
 label: tigu-mpirun
 hostname: 10.128.1.11
 description: Tigu computer at Empa.
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 shebang: '#!/bin/bash -l'
 mpiprocs_per_machine: 4
-queue_name: normal
 work_dir: /scratch/{username}/aiida/
 mpirun_command: mpirun -np {tot_num_mpiprocs}
 prepend_text: |

--- a/tigu.empa.ch/tigu/computer-setup.yaml
+++ b/tigu.empa.ch/tigu/computer-setup.yaml
@@ -2,11 +2,10 @@
 label: tigu
 hostname: 10.128.1.11
 description: Tigu computer at Empa.
-transport: ssh
-scheduler: slurm
+transport: core.ssh
+scheduler: core.slurm
 shebang: '#!/bin/bash -l'
 mpiprocs_per_machine: 4
-queue_name: normal
 work_dir: /scratch/{username}/aiida/
 mpirun_command: srun
 prepend_text: |


### PR DESCRIPTION
In the current state, the computer setup config files don't work with AiiDA v2.7.0, neither the new CSCS Alps infrastructure. Even though we don't recommend this repo, in favor of `aiida-resource-registry`, the latter also doesn't currently work with AiiDA core, due to the use of unsupported jinja2 fields, and the unsupported `metadata` section. Thus, I saw this as an easy fix to have at least one registry for now that contains usable config files.

List of changes:
- `transport: ssh` -> `transport: core.ssh`
- `scheduler: slurm` -> `scheduler: core.slurm`
- `hostname: <hpc>.cscs.ch` -> `hostname: <hpc>.alps.cscs.ch`
- Removed `num_cores_per_mpiproc` for computers with SLURM scheduler
- Removed unsupported `queue_name` field. This should be `partition` set via the `prepend_text` (at least for SLURM)